### PR TITLE
correction of BTCEUR ticker calculation

### DIFF
--- a/lib/ticker.js
+++ b/lib/ticker.js
@@ -15,7 +15,7 @@ function getTickerUrls(currencies) {
   ];
 
   if (currencies.indexOf('EUR') !== -1)
-    urls.push(API_ENDPOINT + 'eur_usd/');
+    urls.push('https://www.bitstamp.net/api/v2/ticker/btceur/');
 
   return urls;
 }
@@ -40,8 +40,8 @@ function formatResponse(currencies, results, callback) {
     response.EUR = {
       currency: 'EUR',
       rates: {
-        ask: parseFloat(usdRate.ask / results[1].sell).toFixed(2),
-        bid: parseFloat(usdRate.bid / results[1].sell).toFixed(2)
+        ask: parseFloat(results[1].ask),
+        bid: parseFloat(results[1].bid)
       }
     };
 


### PR DESCRIPTION
Calculating BTCEUR from BTCUSD / EURUSDsell does not produce valid results in comparison to actual BTCEUR price on BitStamp

This should be a quick/dirty fix hopefully not affecting the rest of the server code. I'm not a JavaScript programmer, so please double-check that this is fine. Thanks.